### PR TITLE
Fix wrong extension pattern

### DIFF
--- a/src/file_explorer_summary.py
+++ b/src/file_explorer_summary.py
@@ -29,7 +29,18 @@ def is_path_excluded(filepath, root, ignore_patterns):
 
 def get_file_paths(directory, ignore_patterns):
     file_paths = []
-    allowed_extensions = [".doc", ".txt", ".json", ".py", ".env", ".bat", ".html", ".js", ".css", "ini"]
+    allowed_extensions = [
+        ".doc",
+        ".txt",
+        ".json",
+        ".py",
+        ".env",
+        ".bat",
+        ".html",
+        ".js",
+        ".css",
+        ".ini",
+    ]
 
     for root, dirs, files in os.walk(directory):
         # Remove ignored directories from dirs to avoid further exploration


### PR DESCRIPTION
## Summary
- correct the `.ini` extension in `file_explorer_summary.get_file_paths`

## Testing
- `python -m py_compile src/*.py`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_683f69b0478883329cc1845fc64ea8d7)