### PR TITLE
Improve summary/index generation and cross-platform opening behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Code Chronicle
 
-Code Chronicle is a Python-based project explorer that generates file indices and script summaries while respecting .gitignore patterns. The project contains a user-friendly GUI built with PyQt5, allowing users to browse folders, select options, and create outputs. This tool can simplify the process of providing full projects to language models (e.g., GPT) as input, by aggregating relevant code and text files into a single summary file.
+Code Chronicle is a Python-based project explorer that generates file indices and script summaries while respecting `.gitignore` patterns. The project contains a user-friendly GUI built with PyQt5, allowing users to browse folders, select options, and create outputs. This tool can simplify the process of providing full projects to language models (e.g., GPT) as input by aggregating relevant code and text files into a single summary file.
 
 ## Installation and Usage
 
@@ -9,7 +9,7 @@ Code Chronicle is a Python-based project explorer that generates file indices an
 - Python 3.x
 - pip (Python package manager)
 
-### Install and Run
+### Install and Run GUI
 
 1. Clone the repository or download the source code.
 2. Navigate to the Code Chronicle folder.
@@ -20,14 +20,32 @@ The `run.bat` script will:
 - Create a virtual environment (if not already present) in the project folder.
 - Activate the virtual environment.
 - Install the required dependencies from `requirements.txt`.
-- Run the Project Explorer script (gui.py).
+- Run the Project Explorer script (`gui.py`).
+
+### CLI Usage
+
+You can also generate outputs from the command line:
+
+```bash
+python src/file_explorer_summary.py [folder] [--summary] [--index] [--output OUTPUT_DIR]
+```
+
+- `folder` (optional): project folder to inspect. Defaults to the current directory.
+- `--summary`: generate `scripts-list.txt`.
+- `--index`: generate `00_file-index.txt`.
+- `--output`: output directory for generated files. Defaults to the current directory.
+
+If neither `--summary` nor `--index` is provided, Code Chronicle generates **both** outputs by default.
 
 ## Features
 
 - Browse and select a project folder.
-- Generate a script summary that consolidates relevant code and text files, making it easy to provide full projects to language models as input.
-- Generate a file index that lists all files in the project, excluding those specified in the .gitignore file.
-- Automatically saves output files to a "chronicle-history" folder.
+- Generate a script summary that consolidates relevant code and text files.
+- Summary exports include a short documentation header and preserve source content verbatim, including comments, docstrings, and blank lines.
+- Generate a readable tree-like file index with stable sorting.
+- Respect `.gitignore` rules (including directory patterns) while traversing files.
+- Automatically save GUI output files to a `chronicle-history` folder.
+- Open generated files/folders with platform-aware behavior (`os.startfile` on Windows, `open` on macOS, and `xdg-open` on Linux).
 
 ## Contributing
 

--- a/src/file_explorer_summary.py
+++ b/src/file_explorer_summary.py
@@ -1,113 +1,197 @@
-import os
+import argparse
 import fnmatch
+import os
+from pathlib import Path
+
+ALLOWED_EXTENSIONS = {
+    ".doc",
+    ".txt",
+    ".json",
+    ".py",
+    ".env",
+    ".bat",
+    ".html",
+    ".js",
+    ".css",
+    ".ini",
+}
+
+SUMMARY_HEADER = (
+    "# Code Chronicle Summary\n"
+    "# The file contents below are copied verbatim from the source files,\n"
+    "# including comments, docstrings, and blank lines.\n\n"
+)
+
+
+def _normalize_relpath(path):
+    normalized = path.replace("\\", "/").strip("/")
+    return normalized
+
+
+def _read_gitignore_patterns(selected_folder):
+    patterns = []
+    gitignore_file = os.path.join(selected_folder, ".gitignore")
+    if not os.path.exists(gitignore_file):
+        return patterns
+
+    with open(gitignore_file, "r", encoding="utf-8", errors="ignore") as file:
+        for raw_line in file:
+            line = raw_line.strip()
+            if not line or line.startswith("#"):
+                continue
+            if line.startswith("!"):
+                # Negation rules are intentionally not supported yet.
+                continue
+            patterns.append(line.replace("\\", "/"))
+    return patterns
 
 
 def get_ignore_patterns(selected_folder):
-    ignore_patterns = []  # Initialize ignore_patterns as an empty list
-    
     script_filename = os.path.basename(__file__)
-    ignore_patterns.extend([script_filename, '.git', '.gitignore'])
-
-    gitignore_file = os.path.join(selected_folder, '.gitignore')
-    if os.path.exists(gitignore_file):
-        with open(gitignore_file, 'r') as file:
-            gitignore_patterns = file.read().splitlines()
-            ignore_patterns.extend(gitignore_patterns)
-
+    ignore_patterns = [script_filename, ".git", ".git/"]
+    ignore_patterns.extend(_read_gitignore_patterns(selected_folder))
     return ignore_patterns
 
 
-def is_path_excluded(filepath, root, ignore_patterns):
-    relative_filepath = os.path.relpath(filepath, root)
-    for pattern in ignore_patterns:
-        if fnmatch.fnmatch(relative_filepath, pattern):
+def _pattern_matches(rel_path, pattern, is_dir):
+    rel_path = _normalize_relpath(rel_path)
+    pattern = pattern.replace("\\", "/")
+    if not pattern:
+        return False
+
+    directory_only = pattern.endswith("/")
+    pattern = pattern.rstrip("/")
+
+    anchored = pattern.startswith("/")
+    pattern = pattern.lstrip("/")
+    if not pattern:
+        return False
+
+    candidates = [rel_path]
+    if not anchored:
+        parts = rel_path.split("/")
+        candidates.extend(["/".join(parts[i:]) for i in range(1, len(parts))])
+
+    for candidate in candidates:
+        if directory_only and not is_dir:
+            continue
+
+        if fnmatch.fnmatch(candidate, pattern):
             return True
-        if os.path.isdir(filepath) and fnmatch.fnmatch(relative_filepath + os.sep, pattern):
+
+        if "/" not in pattern:
+            if candidate == pattern or candidate.startswith(f"{pattern}/"):
+                if not directory_only or is_dir or "/" in rel_path:
+                    return True
+
+        if directory_only and (candidate == pattern or candidate.startswith(f"{pattern}/")):
+            return True
+
+    return False
+
+
+def is_path_excluded(filepath, root, ignore_patterns):
+    rel_path = os.path.relpath(filepath, root)
+    rel_path = _normalize_relpath(rel_path)
+    is_dir = os.path.isdir(filepath)
+
+    for pattern in ignore_patterns:
+        if _pattern_matches(rel_path, pattern, is_dir):
             return True
     return False
 
 
 def get_file_paths(directory, ignore_patterns):
     file_paths = []
-    allowed_extensions = [
-        ".doc",
-        ".txt",
-        ".json",
-        ".py",
-        ".env",
-        ".bat",
-        ".html",
-        ".js",
-        ".css",
-        ".ini",
-    ]
 
     for root, dirs, files in os.walk(directory):
-        # Remove ignored directories from dirs to avoid further exploration
-        dirs[:] = [d for d in dirs if not is_path_excluded(os.path.join(root, d), directory, ignore_patterns)]
-        
-        for file in files:
-            filepath = os.path.join(root, file)
-            if any(file.endswith(extension) for extension in allowed_extensions) and not is_path_excluded(filepath, directory, ignore_patterns):
-                file_paths.append(filepath)
+        dirs[:] = sorted(
+            d for d in dirs if not is_path_excluded(os.path.join(root, d), directory, ignore_patterns)
+        )
+
+        for file_name in sorted(files):
+            file_path = os.path.join(root, file_name)
+            if Path(file_name).suffix.lower() in ALLOWED_EXTENSIONS and not is_path_excluded(
+                file_path, directory, ignore_patterns
+            ):
+                file_paths.append(file_path)
+
     return file_paths
+
 
 def create_output_file(file_paths, output_file_name="scripts-list.txt"):
     with open(output_file_name, "w", encoding="utf-8") as output_file:
-        for file_path in file_paths:
+        output_file.write(SUMMARY_HEADER)
+        for file_path in sorted(file_paths):
             output_file.write(f"########## {file_path} ##########\n")
-            with open(file_path, "r", encoding="utf-8", errors='ignore') as input_file:
-                content = input_file.read()
-                output_file.write(content)
+            with open(file_path, "r", encoding="utf-8", errors="ignore") as input_file:
+                output_file.write(input_file.read())
             output_file.write("\n\n")
 
 
+def _build_tree_lines(startpath, ignore_patterns):
+    root_name = os.path.basename(os.path.abspath(startpath))
+    lines = [f"{root_name}/"]
+
+    def walk_dir(path, prefix=""):
+        entries = []
+        for name in sorted(os.listdir(path)):
+            full_path = os.path.join(path, name)
+            if is_path_excluded(full_path, startpath, ignore_patterns):
+                continue
+            entries.append((name, full_path, os.path.isdir(full_path)))
+
+        for index, (name, full_path, is_dir) in enumerate(entries):
+            connector = "└── " if index == len(entries) - 1 else "├── "
+            child_prefix = "    " if index == len(entries) - 1 else "│   "
+            label = f"{name}/" if is_dir else name
+            lines.append(f"{prefix}{connector}{label}")
+            if is_dir:
+                walk_dir(full_path, prefix + child_prefix)
+
+    walk_dir(startpath)
+    return lines
+
+
 def list_files(startpath, ignore_patterns, output_file_name="00_file-index.txt"):
-    with open(output_file_name, "w", encoding="utf-8") as f:
-        folder_name = os.path.basename(os.path.abspath(startpath))
-        f.write(f"{folder_name}/\n")
-        for root, dirs, files in os.walk(startpath):
-            dirs[:] = [d for d in dirs if not is_path_excluded(os.path.join(root, d), startpath, ignore_patterns)]
-            level = root.replace(startpath, '').count(os.sep)
-            indent = '│   ' * (level - 1) + '├── ' if level > 0 else ''
-            if level == 0:
-                subindent = ''
-            else:
-                is_last_file = False
-                for i, file in enumerate(files):
-                    if not is_path_excluded(os.path.join(root, file), startpath, ignore_patterns):
-                        if i == len(files) - 1:
-                            subindent = '│   ' * level + '└── '
-                            is_last_file = True
-                        else:
-                            subindent = '│   ' * level + '├── '
-                        f.write(f"{indent}{os.path.basename(root)}/\n")
-                        break
-                if is_last_file:
-                    continue
-            for i, file in enumerate(files):
-                if not is_path_excluded(os.path.join(root, file), startpath, ignore_patterns):
-                    if i == len(files) - 1:
-                        subindent = '│   ' * level + '└── '
-                    else:
-                        subindent = '│   ' * level + '├── '
-                    f.write(f"{subindent}{file}\n")
+    lines = _build_tree_lines(startpath, ignore_patterns)
+    with open(output_file_name, "w", encoding="utf-8") as output_file:
+        output_file.write("\n".join(lines) + "\n")
 
 
+def main():
+    parser = argparse.ArgumentParser(description="Generate Code Chronicle summary and/or file index.")
+    parser.add_argument("folder", nargs="?", default=".", help="Folder to inspect (default: current directory)")
+    parser.add_argument("--summary", action="store_true", help="Generate summary output")
+    parser.add_argument("--index", action="store_true", help="Generate file index output")
+    parser.add_argument(
+        "--output",
+        default=".",
+        help="Output directory for generated files (default: current directory)",
+    )
+    args = parser.parse_args()
 
-if __name__ == '__main__':
-    current_directory = os.getcwd()
+    selected_folder = os.path.abspath(args.folder)
+    output_dir = os.path.abspath(args.output)
+    os.makedirs(output_dir, exist_ok=True)
 
-    # Get the folder path from the GUI
-    selected_folder = os.path.abspath("path_to_the_selected_folder")  # Replace this with the actual folder path from the GUI
+    generate_summary = args.summary
+    generate_index = args.index
+    if not generate_summary and not generate_index:
+        generate_summary = True
+        generate_index = True
 
-    # Get the ignore patterns
     ignore_patterns = get_ignore_patterns(selected_folder)
 
-    # Generate the scripts-list.txt file
-    file_paths = get_file_paths(current_directory, ignore_patterns)
-    create_output_file(file_paths)
+    if generate_summary:
+        summary_path = os.path.join(output_dir, "scripts-list.txt")
+        file_paths = get_file_paths(selected_folder, ignore_patterns)
+        create_output_file(file_paths, summary_path)
 
-    # Generate the file_list.txt file
-    start_path = '.'  # current directory
-    list_files(start_path, ignore_patterns)
+    if generate_index:
+        index_path = os.path.join(output_dir, "00_file-index.txt")
+        list_files(selected_folder, ignore_patterns, index_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/gui.py
+++ b/src/gui.py
@@ -9,6 +9,15 @@ from PyQt5.QtWidgets import (QApplication, QWidget, QLabel, QPushButton, QFileDi
 
 from file_explorer_summary import get_ignore_patterns, list_files, create_output_file, get_file_paths
 
+
+def open_path(path):
+    if sys.platform.startswith('win'):
+        os.startfile(path)
+    elif sys.platform == 'darwin':
+        subprocess.Popen(['open', path], close_fds=True)
+    else:
+        subprocess.Popen(['xdg-open', path], close_fds=True)
+
 def get_main_folder():
     # Assuming gui.py is located in src folder in the main project folder
     return os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
@@ -82,19 +91,19 @@ class ProjectExplorer(QWidget):
             output_file_path = os.path.join(history_folder, output_file_name)
             file_paths = get_file_paths(self.folder_name, ignore_patterns)
             create_output_file(file_paths, output_file_path)
-            subprocess.Popen(['notepad.exe', output_file_path], close_fds=True)
+            open_path(output_file_path)
 
         if self.index_checkbox.isChecked():
             output_file_name = f"{os.path.basename(self.folder_name)}_file-index_{timestamp}.txt"
             output_file_path = os.path.join(history_folder, output_file_name)
             list_files(self.folder_name, ignore_patterns, output_file_path)
-            subprocess.Popen(['notepad.exe', output_file_path], close_fds=True)
+            open_path(output_file_path)
 
 
     def open_history_folder(self):
         main_folder = get_main_folder()
         history_folder = os.path.join(main_folder, "chronicle-history")
-        os.startfile(history_folder)
+        open_path(history_folder)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### Motivation
- Provide a deterministic, cross-platform tool to produce a verbatim project summary and a readable file index while honoring `.gitignore` directory patterns. 
- Make the file-explorer functionality usable from the CLI with sensible default behavior when flags are omitted. 
- Ensure the GUI opens generated files/folders in a platform-aware way instead of Windows-only launchers.

### Description
- Refactored `src/file_explorer_summary.py` into a CLI tool using `argparse` with an optional `folder` positional argument and `--summary`, `--index`, and `--output` flags, and defaulting to generate both outputs when no flags are given. 
- Implemented robust `.gitignore` parsing that skips blank/commented lines, normalizes separators, ignores negation rules for now, and matches directory-style patterns so nested ignored paths are excluded during traversal. 
- Made traversal deterministic by sorting directory and file listings and switched the index renderer to a stable tree format using `├──` / `└──` connectors via a `_build_tree_lines` helper. 
- Ensured summary exports preserve file contents verbatim and prepend a short explanatory header (`SUMMARY_HEADER`) that documents this behavior. 
- Updated `src/gui.py` to use a new `open_path` helper that calls `os.startfile` on Windows, `open` on macOS, and `xdg-open` on Linux when opening generated files or the history folder. 
- Updated `README.md` to document CLI usage, the default behavior when flags are omitted, and the guarantee that summary exports preserve comments/docstrings and include the documentation header.

### Testing
- Ran `python src/file_explorer_summary.py --help` to validate the CLI usage output, which succeeded. 
- Created a temporary project tree with a `.gitignore` containing a directory pattern and ran the tool to verify the index and summary outputs, confirming the ignored directory was excluded and the index used tree connectors; output inspection succeeded. 
- Verified `--index` only mode creates `00_file-index.txt` and does not create `scripts-list.txt` by running the CLI in a temporary directory, which returned `ok` (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997535c6d688332af81e174b75055a0)