### PR TITLE
Improve cross-platform launch and GUI reliability

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,35 @@
 # Code Chronicle
 
-Code Chronicle is a Python-based project explorer that generates file indices and script summaries while respecting `.gitignore` patterns. The project contains a user-friendly GUI built with PyQt5, allowing users to browse folders, select options, and create outputs. This tool can simplify the process of providing full projects to language models (e.g., GPT) as input by aggregating relevant code and text files into a single summary file.
+Code Chronicle is a Python-based project explorer that generates file indices and script summaries while respecting `.gitignore` patterns. The project includes a GUI built with PyQt5 so users can browse folders, choose output options, and generate files without memorizing CLI flags.
 
-## Installation and Usage
+## What it generates
 
-### Prerequisites
+- `scripts-list.txt`: concatenated content of supported project files, with a short header.
+- `00_file-index.txt`: readable tree index of files/folders.
 
-- Python 3.x
-- pip (Python package manager)
+Both outputs honor `.gitignore` exclusions (except negation rules such as `!pattern`, which are intentionally unsupported).
 
-### Install and Run GUI
+## Quick start (no terminal required)
 
-1. Clone the repository or download the source code.
-2. Navigate to the Code Chronicle folder.
-3. Double-click on `run.bat` to install the required dependencies and launch the application in one shot.
+### Windows
 
-The `run.bat` script will:
+1. Download/clone the project.
+2. Double-click `run.bat`.
 
-- Create a virtual environment (if not already present) in the project folder.
-- Activate the virtual environment.
-- Install the required dependencies from `requirements.txt`.
-- Run the Project Explorer script (`gui.py`).
+### macOS / Linux
 
-### CLI Usage
+1. Download/clone the project.
+2. Double-click `run.sh` (or run `./run.sh` once from Terminal if your file manager requires execute permission confirmation).
 
-You can also generate outputs from the command line:
+The launcher scripts:
+
+- create a local virtual environment in `.venv` (inside the project folder),
+- install dependencies from `requirements.txt` into that virtual environment,
+- run the GUI.
+
+This keeps dependencies local to the project and avoids global package pollution.
+
+## CLI usage
 
 ```bash
 python src/file_explorer_summary.py [folder] [--summary] [--index] [--output OUTPUT_DIR]
@@ -35,18 +40,25 @@ python src/file_explorer_summary.py [folder] [--summary] [--index] [--output OUT
 - `--index`: generate `00_file-index.txt`.
 - `--output`: output directory for generated files. Defaults to the current directory.
 
-If neither `--summary` nor `--index` is provided, Code Chronicle generates **both** outputs by default.
+If neither `--summary` nor `--index` is provided, Code Chronicle generates both outputs.
 
 ## Features
 
-- Browse and select a project folder.
-- Generate a script summary that consolidates relevant code and text files.
-- Summary exports include a short documentation header and preserve source content verbatim, including comments, docstrings, and blank lines.
-- Generate a readable tree-like file index with stable sorting.
-- Respect `.gitignore` rules (including directory patterns) while traversing files.
-- Automatically save GUI output files to a `chronicle-history` folder.
-- Open generated files/folders with platform-aware behavior (`os.startfile` on Windows, `open` on macOS, and `xdg-open` on Linux).
+- Folder picker-based GUI.
+- Defaults to generating both summary and index.
+- Prevents running with invalid folders.
+- Writes GUI outputs into `chronicle-history/`.
+- Platform-aware opening behavior:
+  - Windows: `os.startfile`
+  - macOS: `open`
+  - Linux: `xdg-open`
+- Stable sorting for deterministic outputs.
+
+## Notes
+
+- Supported summary extensions: `.doc`, `.txt`, `.json`, `.py`, `.env`, `.bat`, `.html`, `.js`, `.css`, `.ini`.
+- `.gitignore` negation entries (`!`) are skipped by design.
 
 ## Contributing
 
-Feel free to submit issues, feature requests, or pull requests. Your feedback and contributions are welcome and appreciated.
+Issues and pull requests are welcome.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,2 @@
-pyinstaller
 PyQt5
-pipenv
 zipp>=3.19.1 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/run.bat
+++ b/run.bat
@@ -1,17 +1,16 @@
 @echo off
+setlocal
 
-if not exist env (
+if not exist .venv (
     echo Creating virtual environment in the project folder...
-    python -m venv env
+    py -3 -m venv .venv
 )
 
-call env\Scripts\activate.bat
+call .venv\Scripts\activate.bat
 
 echo Installing dependencies from requirements.txt...
-pip install -r requirements.txt
+python -m pip install --upgrade pip
+python -m pip install -r requirements.txt
 
-echo Running the Project Explorer script...
+echo Running Code Chronicle...
 python src\gui.py
-
-echo Done.
-pause

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ ! -d ".venv" ]; then
+  echo "Creating virtual environment in the project folder..."
+  python3 -m venv .venv
+fi
+
+# shellcheck disable=SC1091
+source .venv/bin/activate
+
+echo "Installing dependencies from requirements.txt..."
+python -m pip install --upgrade pip
+python -m pip install -r requirements.txt
+
+echo "Running Code Chronicle..."
+python src/gui.py


### PR DESCRIPTION
### Motivation
- Make the project easier for non-technical users to run without polluting the system Python environment by using a local virtualenv and simple double-click launchers. 
- Clarify README and user expectations about what the tool generates and its `.gitignore` behavior. 
- Harden the GUI so it is clearer and less likely to fail silently when a user provides invalid input or when platform-specific open commands fail. 
- Reduce unnecessary runtime dependencies to avoid installing packages that are not needed for the GUI to run.

### Description
- Added a macOS/Linux launcher `run.sh` and updated `run.bat` to create/use a project-local `.venv` and invoke `python -m pip` for installs to avoid global package pollution. 
- Rewrote `README.md` to document cross-platform launchers and no-terminal usage and to list outputs and limitations. 
- Trimmed `requirements.txt` to the needed runtime dependency `PyQt5` and retained the `zipp` pin. 
- Improved `src/gui.py` with better imports, a help label, default-checked output options, validation that the chosen folder exists before enabling `Generate`, user-facing `QMessageBox` dialogs for invalid input/no selection/completion, and safer `open_path` usage with try/except handling for desktop open failures; `open_history_folder` now ensures the history directory exists before attempting to open it.

### Testing
- Successfully type-checked/compiled the runtime modules with `python -m py_compile src/file_explorer_summary.py src/gui.py`. (passed)
- Executed the CLI generator with `python src/file_explorer_summary.py . --summary --index --output /tmp/code-chronicle-check` and observed generated files (counts reported). (passed)
- Verified `.gitignore` exclusion logic using an inline temporary-directory Python test that asserted only allowed files were returned by `get_file_paths`. (passed)
- Attempted a GUI smoke test with `QT_QPA_PLATFORM=offscreen python ...` but the environment lacked `libGL.so.1`, causing an ImportError and preventing full GUI runtime validation in this CI-like environment (test blocked by missing system library). (blocked)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699755d8b9e083328ac65e6c1f5e7f50)